### PR TITLE
Better ENV detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod otlp;
 pub mod test;
 
 mod filter;
+mod util;
 
 #[derive(Debug, Default)]
 pub struct DetectResource {
@@ -84,18 +85,16 @@ pub struct ServiceInfoDetector {
 
 impl ResourceDetector for ServiceInfoDetector {
     fn detect(&self, _timeout: std::time::Duration) -> Resource {
-        let service_name = std::env::var("OTEL_SERVICE_NAME")
-            .or_else(|_| std::env::var("SERVICE_NAME"))
-            .or_else(|_| std::env::var("APP_NAME"))
-            .ok()
+        let service_name = util::env_var("OTEL_SERVICE_NAME")
+            .or_else(|| util::env_var("SERVICE_NAME"))
+            .or_else(|| util::env_var("APP_NAME"))
             .or_else(|| Some(self.fallback_service_name.to_string()))
             .map(|v| {
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME.string(v)
             });
-        let service_version = std::env::var("OTEL_SERVICE_VERSION")
-            .or_else(|_| std::env::var("SERVICE_VERSION"))
-            .or_else(|_| std::env::var("APP_VERSION"))
-            .ok()
+        let service_version = util::env_var("OTEL_SERVICE_VERSION")
+            .or_else(|| util::env_var("SERVICE_VERSION"))
+            .or_else(|| util::env_var("APP_VERSION"))
             .or_else(|| Some(self.fallback_service_version.to_string()))
             .map(|v| {
                 opentelemetry_semantic_conventions::resource::SERVICE_VERSION.string(v)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub fn init_tracing_with_fallbacks(
         otlp::init_tracer(otel_rsrc, otlp::identity).expect("setup of Tracer");
 
     opentelemetry::global::set_text_map_propagator(
-        propagation::TextMapSplitPropagator::default(),
+        propagation::TextMapSplitPropagator::from_env().expect("setup of Propagation"),
     );
 
     let otel_layer = tracing_opentelemetry::layer()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/blob/d3609ac2cc699d3a24fbf89754053cc8e938e3bf/LICENSE
 
 use opentelemetry_sdk::{
-    resource::{OsResourceDetector, ResourceDetector},
+    resource::{EnvResourceDetector, OsResourceDetector, ResourceDetector},
     Resource,
 };
 use tracing::{level_filters::LevelFilter, Subscriber};
@@ -63,7 +63,7 @@ impl DetectResource {
                     fallback_service_version: self.fallback_service_version,
                 }),
                 Box::new(OsResourceDetector),
-                //Box::new(ProcessResourceDetector),
+                Box::new(EnvResourceDetector::new()),
             ],
         );
         let rsrc = base.merge(&fallback); // base has lower priority

--- a/src/propagation.rs
+++ b/src/propagation.rs
@@ -2,16 +2,34 @@ use opentelemetry::{
     propagation::{
         text_map_propagator::FieldIter, Extractor, Injector, TextMapPropagator,
     },
+    trace::TraceError,
     Context,
 };
 use opentelemetry_sdk::propagation::{
-    TextMapCompositePropagator, TraceContextPropagator,
+    BaggagePropagator, TextMapCompositePropagator, TraceContextPropagator,
 };
 #[cfg(feature = "zipkin")]
 use opentelemetry_zipkin::{B3Encoding, Propagator as B3Propagator};
 use std::collections::BTreeSet;
 
+use crate::util;
+
 pub type Propagator = Box<dyn TextMapPropagator + Send + Sync>;
+
+#[derive(Debug)]
+pub struct NonePropagator;
+
+impl TextMapPropagator for NonePropagator {
+    fn inject_context(&self, _: &Context, _: &mut dyn Injector) {}
+
+    fn extract_with_context(&self, cx: &Context, _: &dyn Extractor) -> Context {
+        cx.clone()
+    }
+
+    fn fields(&self) -> FieldIter<'_> {
+        FieldIter::new(&[])
+    }
+}
 
 #[derive(Debug)]
 pub struct TextMapSplitPropagator {
@@ -31,6 +49,34 @@ impl TextMapSplitPropagator {
             inject_propagator,
             fields,
         }
+    }
+
+    pub fn from_env() -> Result<Self, TraceError> {
+        let value_from_env = match util::env_var("OTEL_PROPAGATORS") {
+            Some(value) => value,
+            None => {
+                return Ok(Self::default());
+            }
+        };
+        let propagators: Vec<String> = value_from_env
+            .split(',')
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let inject_propagator = if let Some(name) = propagators.first() {
+            propagator_from_string(name)?
+        } else {
+            Box::new(NonePropagator)
+        };
+        let extract_propagators: Vec<Propagator> = propagators
+            .into_iter()
+            .map(|s| propagator_from_string(&s.trim().to_lowercase()))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let extract_propagator =
+            Box::new(TextMapCompositePropagator::new(extract_propagators));
+        Ok(Self::new(extract_propagator, inject_propagator))
     }
 }
 
@@ -63,5 +109,39 @@ impl Default for TextMapSplitPropagator {
             Box::new(composite_propagator),
             Box::new(trace_context_propagator),
         )
+    }
+}
+
+fn propagator_from_string(v: &str) -> Result<Propagator, TraceError> {
+    match v.trim() {
+        "tracecontext" => Ok(Box::new(TraceContextPropagator::new())),
+        "baggage" => Ok(Box::new(BaggagePropagator::new())),
+        #[cfg(feature = "zipkin")]
+        "b3" => Ok(Box::new(B3Propagator::with_encoding(B3Encoding::SingleHeader))),
+        #[cfg(not(feature = "zipkin"))]
+        "b3" => Err(TraceError::from(
+            "unsupported propagator form env OTEL_PROPAGATORS: 'b3', try to enable compile feature 'zipkin'"
+        )),
+        #[cfg(feature = "zipkin")]
+        "b3multi" => Ok(Box::new(B3Propagator::with_encoding(B3Encoding::MultipleHeader))),
+        #[cfg(not(feature = "zipkin"))]
+        "b3multi" => Err(TraceError::from(
+            "unsupported propagator form env OTEL_PROPAGATORS: 'b3multi', try to enable compile feature 'zipkin'"
+        )),
+        "none" => Ok(Box::new(NonePropagator)),
+        unknown => Err(TraceError::from(format!(
+            "unsupported propagator form env OTEL_PROPAGATORS: {unknown:?}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "tracer")]
+mod tests {
+    use assert2::let_assert;
+
+    #[test]
+    fn init_tracing_failed_on_invalid_propagator() {
+        let_assert!(Err(_) = super::propagator_from_string("xxxxxx"));
     }
 }

--- a/src/propagation.rs
+++ b/src/propagation.rs
@@ -11,18 +11,17 @@ use opentelemetry_sdk::propagation::{
 use opentelemetry_zipkin::{B3Encoding, Propagator as B3Propagator};
 use std::collections::BTreeSet;
 
+pub type Propagator = Box<dyn TextMapPropagator + Send + Sync>;
+
 #[derive(Debug)]
 pub struct TextMapSplitPropagator {
-    extract_propagator: Box<dyn TextMapPropagator + Send + Sync>,
-    inject_propagator: Box<dyn TextMapPropagator + Send + Sync>,
+    extract_propagator: Propagator,
+    inject_propagator: Propagator,
     fields: Vec<String>,
 }
 
 impl TextMapSplitPropagator {
-    pub fn new(
-        extract_propagator: Box<dyn TextMapPropagator + Send + Sync>,
-        inject_propagator: Box<dyn TextMapPropagator + Send + Sync>,
-    ) -> Self {
+    pub fn new(extract_propagator: Propagator, inject_propagator: Propagator) -> Self {
         let mut fields = BTreeSet::from_iter(extract_propagator.fields());
         fields.extend(inject_propagator.fields());
         let fields = fields.into_iter().map(String::from).collect();

--- a/src/propagation.rs
+++ b/src/propagation.rs
@@ -63,6 +63,7 @@ impl TextMapSplitPropagator {
             .map(|s| s.trim().to_lowercase())
             .filter(|s| !s.is_empty())
             .collect();
+        tracing::debug!(target: "otel::setup", propagators = propagators.join(","));
 
         let inject_propagator = if let Some(name) = propagators.first() {
             propagator_from_string(name)?

--- a/src/propagation.rs
+++ b/src/propagation.rs
@@ -7,6 +7,7 @@ use opentelemetry::{
 use opentelemetry_sdk::propagation::{
     TextMapCompositePropagator, TraceContextPropagator,
 };
+#[cfg(feature = "zipkin")]
 use opentelemetry_zipkin::{B3Encoding, Propagator as B3Propagator};
 use std::collections::BTreeSet;
 
@@ -51,9 +52,11 @@ impl TextMapPropagator for TextMapSplitPropagator {
 impl Default for TextMapSplitPropagator {
     fn default() -> Self {
         let trace_context_propagator = TraceContextPropagator::new();
+        #[cfg(feature = "zipkin")]
         let b3_propagator = B3Propagator::with_encoding(B3Encoding::SingleAndMultiHeader);
         let composite_propagator = TextMapCompositePropagator::new(vec![
             Box::new(trace_context_propagator.clone()),
+            #[cfg(feature = "zipkin")]
             Box::new(b3_propagator),
         ]);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,13 @@
+#[inline]
+pub fn env_var(key: &str) -> Option<String> {
+    match std::env::var(key) {
+        Ok(value) => {
+            if value.trim().is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        }
+        Err(_) => None,
+    }
+}


### PR DESCRIPTION
This PR adds support for the following ENV variables:

 * `OTEL_RESOURCE_ATTRIBUTES` - was ignored before
 * `OTEL_PROPAGATORS` - we were using a very good default value instead

Also, having empty values in any of the `OTEL_*` variables no longer break the library.

**N.B.:** this PR does nothing to address performance issues in the latest major release of `telemetry-rust`, so be careful using it for now.