### PR TITLE
Improve aws span implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Creating new span:
 
 ```rust
 // create new span directly by using current span context
-let aws_span = AwsSpan::new(AwsTarget::Dynamo("table_name"), "MyOperation", "GET");
+let aws_span = AwsSpan::new(AwsTarget::Dynamo("table_name"), "TransactGetItems");
 
 // or by providing an explicit parent context
 let context = Span::current().context();
-let aws_span = AwsSpan::with_context(AwsTarget::Dynamo("table_name"), "MyOperation", "GET", &context);
+let aws_span = AwsSpan::with_context(AwsTarget::Dynamo("table_name"), "TransactGetItems", &context);
 
 // or build it using builder pattern
-let builder = AwsSpan::build(AwsTarget::Dynamo("table_name"), "MyOperation", "GET")
+let builder = AwsSpan::build(AwsTarget::Dynamo("table_name"), "TransactGetItems")
 let aws_span = builder.start();
 let aws_span = builder.start_with_context(&context);
 ```
@@ -59,4 +59,23 @@ let res = dynamo_client
     .send()
     .await;
 aws_span.end(&res);
+```
+
+Defining a custom aws target:
+
+```rust
+struct S3Target {}
+impl IntoAttributes for S3Target {
+    fn service(&self) -> &'static str {
+        "s3"
+    }
+
+    fn into_attributes(self, _method: &'static str) -> Vec<KeyValue> {
+        vec![semcov::AWS_S3_BUCKET.string("my_bucket")]
+    }
+}
+```
+
+```rust
+let s3_span = AwsSpan::new(S3Target {}, "GetObject");
 ```

--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ Creating new span:
 
 ```rust
 // create new span directly by using current span context
-let aws_span = AwsSpan::new(AwsTarget::Dynamo("table_name"), "TransactGetItems");
+let aws_span = AwsSpan::new(AwsTarget::Dynamo("table_name"), "GetItem");
 
 // or by providing an explicit parent context
 let context = Span::current().context();
-let aws_span = AwsSpan::with_context(AwsTarget::Dynamo("table_name"), "TransactGetItems", &context);
+let aws_span = AwsSpan::with_context(AwsTarget::Dynamo("table_name"), "GetItem", &context);
 
 // or build it using builder pattern
-let builder = AwsSpan::build(AwsTarget::Dynamo("table_name"), "TransactGetItems")
+let builder = AwsSpan::build(AwsTarget::Dynamo("table_name"), "GetItem")
+    .set_attribute(semcov::AWS_DYNAMODB_INDEX_NAME.string("my_index"));
 let aws_span = builder.start();
 let aws_span = builder.start_with_context(&context);
 ```
@@ -54,8 +55,10 @@ Ending the span once AWS operation is complete:
 
 ```rust
 let res = dynamo_client
-    .transact_get_items()
-    .set_transact_items(Some(transact_items))
+    .get_item()
+    .table_name("table_name")
+    .index_name("my_index")
+    .set_key(primary_key)
     .send()
     .await;
 aws_span.end(&res);

--- a/README.md
+++ b/README.md
@@ -31,3 +31,32 @@ async fn main() {
 
     // ...
 ```
+
+## AWS instrumentation
+
+Creating new span:
+
+```rust
+// create new span directly by using current span context
+let aws_span = AwsSpan::new(AwsTarget::Dynamo("table_name"), "MyOperation", "GET");
+
+// or by providing an explicit parent context
+let context = Span::current().context();
+let aws_span = AwsSpan::with_context(AwsTarget::Dynamo("table_name"), "MyOperation", "GET", &context);
+
+// or build it using builder pattern
+let builder = AwsSpan::build(AwsTarget::Dynamo("table_name"), "MyOperation", "GET")
+let aws_span = builder.start();
+let aws_span = builder.start_with_context(&context);
+```
+
+Ending the span once AWS operation is complete:
+
+```rust
+let res = dynamo_client
+    .transact_get_items()
+    .set_transact_items(Some(transact_items))
+    .send()
+    .await;
+aws_span.end(&res);
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 
-pub use opentelemetry::Context;
-pub use tracing_opentelemetry::OpenTelemetrySpanExt;
+pub use opentelemetry::{Array, Context, Key, KeyValue, StringValue, Value};
 pub use opentelemetry_semantic_conventions::trace as semcov;
+pub use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 pub mod middleware;
 pub mod propagation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::layer::SubscriberExt;
 
 pub use opentelemetry::Context;
 pub use tracing_opentelemetry::OpenTelemetrySpanExt;
+pub use opentelemetry_semantic_conventions::trace as semcov;
 
 pub mod middleware;
 pub mod propagation;

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -25,22 +25,22 @@ impl AwsTarget<'_> {
         }
     }
 
-    pub fn attributes(&self, operation: &str) -> Vec<KeyValue> {
+    pub fn attributes(&self, operation: impl Into<StringValue>) -> Vec<KeyValue> {
         match self {
             AwsTarget::Dynamo(table_name) => vec![
                 semcov::DB_SYSTEM.string("dynamodb"),
-                semcov::DB_OPERATION.string(operation.to_string()),
+                semcov::DB_OPERATION.string(operation),
                 semcov::AWS_DYNAMODB_TABLE_NAMES
                     .array(vec![Into::<StringValue>::into(table_name.to_string())]),
             ],
             AwsTarget::Firehose(stream_name) => vec![
                 semcov::MESSAGING_SYSTEM.string("firehose"),
-                semcov::MESSAGING_OPERATION.string(operation.to_string()),
+                semcov::MESSAGING_OPERATION.string(operation),
                 semcov::MESSAGING_DESTINATION_NAME.string(stream_name.to_string()),
             ],
             AwsTarget::Sns(topic_arn) => vec![
                 semcov::MESSAGING_SYSTEM.string("sns"),
-                semcov::MESSAGING_OPERATION.string(operation.to_string()),
+                semcov::MESSAGING_OPERATION.string(operation),
                 semcov::MESSAGING_DESTINATION_NAME.string(topic_arn.to_string()),
             ],
         }
@@ -53,11 +53,15 @@ pub struct AwsSpanBuilder {
 }
 
 impl AwsSpanBuilder {
-    pub fn new(aws_target: AwsTarget, operation: &str, method: &str) -> Self {
+    pub fn new(
+        aws_target: AwsTarget,
+        operation: impl Into<StringValue>,
+        method: impl Into<StringValue>,
+    ) -> Self {
         let tracer = global::tracer("aws_sdk");
         let service = aws_target.service();
         let mut attributes: Vec<KeyValue> = vec![
-            semcov::RPC_METHOD.string(method.to_string()),
+            semcov::RPC_METHOD.string(method),
             semcov::RPC_SYSTEM.string("aws-api"),
             semcov::RPC_SERVICE.string(service),
         ];
@@ -86,7 +90,11 @@ pub struct AwsSpan {
 }
 
 impl AwsSpan {
-    pub fn new(aws_target: AwsTarget, operation: &str, method: &str) -> AwsSpanBuilder {
+    pub fn new(
+        aws_target: AwsTarget,
+        operation: impl Into<StringValue>,
+        method: impl Into<StringValue>,
+    ) -> AwsSpanBuilder {
         AwsSpanBuilder::new(aws_target, operation, method)
     }
 

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -35,7 +35,7 @@ impl<T: Into<StringValue>> IntoAttributes for AwsTarget<T> {
         match self {
             AwsTarget::Dynamo(_) => SpanKind::Client,
             AwsTarget::Firehose(_) => SpanKind::Producer,
-            AwsTarget::Sns(_) => SpanKind::Consumer,
+            AwsTarget::Sns(_) => SpanKind::Producer,
         }
     }
 

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -93,12 +93,32 @@ pub struct AwsSpan {
 }
 
 impl AwsSpan {
-    pub fn new(
+    #[inline]
+    pub fn build(
         aws_target: impl IntoAttributes,
         operation: impl Into<StringValue>,
         method: impl Into<StringValue>,
     ) -> AwsSpanBuilder {
         AwsSpanBuilder::new(aws_target, operation, method)
+    }
+
+    #[inline]
+    pub fn new(
+        aws_target: impl IntoAttributes,
+        operation: impl Into<StringValue>,
+        method: impl Into<StringValue>,
+    ) -> Self {
+        Self::build(aws_target, operation, method).start()
+    }
+
+    #[inline]
+    pub fn new_with_context(
+        aws_target: impl IntoAttributes,
+        operation: impl Into<StringValue>,
+        method: impl Into<StringValue>,
+        parent_cx: &Context,
+    ) -> Self {
+        Self::build(aws_target, operation, method).start_with_context(parent_cx)
     }
 
     pub fn end<T, E>(self, aws_response: &Result<T, E>)

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -90,6 +90,12 @@ impl AwsSpanBuilder {
         Self { inner, tracer }
     }
 
+    pub fn set_attribute(&mut self, attribute: KeyValue) {
+        if let Some(attributes) = &mut self.inner.attributes {
+            attributes.push(attribute);
+        }
+    }
+
     pub fn start_with_context(self, parent_cx: &Context) -> AwsSpan {
         self.inner
             .start_with_context(&self.tracer, parent_cx)

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -2,13 +2,11 @@ use aws_types::request_id::RequestId;
 use opentelemetry::{
     global::{self, BoxedSpan, BoxedTracer},
     trace::{Span as TelemetrySpan, SpanBuilder, SpanKind, Status, Tracer},
-    Context, KeyValue, StringValue,
 };
 use std::error::Error;
 use tracing::Span;
-use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::semcov;
+use crate::{semcov, Context, KeyValue, OpenTelemetrySpanExt, StringValue};
 
 pub enum AwsTarget<'a> {
     Dynamo(&'a str),

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -3,7 +3,7 @@ use opentelemetry::{
     global::{self, BoxedSpan, BoxedTracer},
     trace::{Span as TelemetrySpan, SpanBuilder, SpanKind, Status, Tracer},
 };
-use std::{error::Error, fmt::Display};
+use std::error::Error;
 use tracing::Span;
 
 use crate::{semcov, Context, KeyValue, OpenTelemetrySpanExt, StringValue};

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -16,7 +16,9 @@ pub enum AwsTarget<T: Into<StringValue>> {
 
 pub trait IntoAttributes {
     fn service(&self) -> &'static str;
-    fn span_kind(&self) -> SpanKind;
+    fn span_kind(&self) -> SpanKind {
+        SpanKind::Client
+    }
     fn into_attributes(self, method: &'static str) -> Vec<KeyValue>;
 }
 

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -112,7 +112,7 @@ impl AwsSpan {
     }
 
     #[inline]
-    pub fn new_with_context(
+    pub fn with_context(
         aws_target: impl IntoAttributes,
         operation: impl Into<StringValue>,
         method: impl Into<StringValue>,

--- a/src/middleware/aws.rs
+++ b/src/middleware/aws.rs
@@ -25,7 +25,7 @@ impl AwsTarget<'_> {
         }
     }
 
-    pub fn attributes(&self, operation: impl Into<StringValue>) -> Vec<KeyValue> {
+    pub fn into_attributes(self, operation: impl Into<StringValue>) -> Vec<KeyValue> {
         match self {
             AwsTarget::Dynamo(table_name) => vec![
                 semcov::DB_SYSTEM.string("dynamodb"),
@@ -65,7 +65,7 @@ impl AwsSpanBuilder {
             semcov::RPC_SYSTEM.string("aws-api"),
             semcov::RPC_SERVICE.string(service),
         ];
-        attributes.extend(aws_target.attributes(operation));
+        attributes.extend(aws_target.into_attributes(operation));
         let inner = tracer
             .span_builder(format!("aws_{service}"))
             .with_attributes(attributes)


### PR DESCRIPTION
This PR:

 * replaces `AwsSpan` enum with a more efficient builder pattern using two structs: `AwsSpan` and `AwsSpanBuilder` (no more panics!)
 * uses generic `Into<StringValue>` instead of `&srt` to avoid cloning static strings
 * adds `IntoAttributes` trait to let users define their own aws targets
 * adds readme
 * follow semantic conventions more closely (i.e. [this one](https://opentelemetry.io/docs/specs/semconv/cloud-providers/aws-sdk/))
 * use [@opentelemetry/instrumentation-aws-sdk](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts) as a reference