### PR TITLE
Cleanup unused legacy semconv tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,13 @@ use tracing_subscriber::layer::SubscriberExt;
 use opentelemetry::trace::TracerProvider as _;
 pub use opentelemetry::{global, Array, Context, Key, KeyValue, StringValue, Value};
 pub use opentelemetry_sdk::trace::TracerProvider;
+pub use opentelemetry_semantic_conventions::attribute as semconv;
 pub use tracing_opentelemetry::{OpenTelemetryLayer, OpenTelemetrySpanExt};
 
 pub mod http;
 pub mod middleware;
 pub mod otlp;
 pub mod propagation;
-pub mod semconv;
 
 #[cfg(feature = "axum")]
 pub use tracing_opentelemetry_instrumentation_sdk;

--- a/src/middleware/aws/operations/dynamodb.rs
+++ b/src/middleware/aws/operations/dynamodb.rs
@@ -2,6 +2,9 @@ use crate::{semconv, Key, KeyValue, StringValue};
 
 use super::*;
 
+#[allow(deprecated)]
+pub const LEGACY_DB_NAME: &str = semconv::DB_NAME;
+
 pub enum DynamodbSpanBuilder {}
 
 impl<'a> AwsSpanBuilder<'a> {
@@ -15,14 +18,13 @@ impl<'a> AwsSpanBuilder<'a> {
         let mut attributes = vec![
             KeyValue::new(semconv::DB_SYSTEM, "dynamodb"),
             KeyValue::new(semconv::DB_OPERATION_NAME, method.clone()),
-            KeyValue::new(semconv::legacy::DB_OPERATION, method.clone()),
         ];
         match table_names.len() {
             0 => {}
             1 => {
                 attributes.extend([
+                    KeyValue::new(LEGACY_DB_NAME, table_names[0].clone()),
                     KeyValue::new(semconv::DB_NAMESPACE, table_names[0].clone()),
-                    KeyValue::new(semconv::legacy::DB_NAME, table_names[0].clone()),
                     Key::new(semconv::AWS_DYNAMODB_TABLE_NAMES).array(table_names),
                 ]);
             }
@@ -72,8 +74,8 @@ macro_rules! dynamodb_table_arn_operation {
                     std::iter::empty::<StringValue>(),
                 )
                 .attributes(vec![
-                    KeyValue::new(semconv::DB_NAMESPACE, table_arn.clone()),
-                    KeyValue::new(semconv::legacy::DB_NAME, table_arn),
+                    KeyValue::new(LEGACY_DB_NAME, table_arn.clone()),
+                    KeyValue::new(semconv::DB_NAMESPACE, table_arn),
                 ])
             }
         }

--- a/src/middleware/aws/operations/firehose.rs
+++ b/src/middleware/aws/operations/firehose.rs
@@ -13,10 +13,6 @@ impl<'a> AwsSpanBuilder<'a> {
         let mut attributes = vec![
             KeyValue::new(semconv::MESSAGING_SYSTEM, "aws_firehose"),
             KeyValue::new(semconv::MESSAGING_OPERATION_TYPE, operation_kind.as_str()),
-            KeyValue::new(
-                semconv::legacy::MESSAGING_OPERATION,
-                operation_kind.as_str(),
-            ),
         ];
         if let Some(stream_name) = stream_name {
             attributes.push(KeyValue::new(

--- a/src/middleware/aws/operations/sns.rs
+++ b/src/middleware/aws/operations/sns.rs
@@ -13,10 +13,6 @@ impl<'a> AwsSpanBuilder<'a> {
         let mut attributes = vec![
             KeyValue::new(semconv::MESSAGING_SYSTEM, "aws_sns"),
             KeyValue::new(semconv::MESSAGING_OPERATION_TYPE, operation_kind.as_str()),
-            KeyValue::new(
-                semconv::legacy::MESSAGING_OPERATION,
-                operation_kind.as_str(),
-            ),
         ];
         if let Some(topic_arn) = topic_arn {
             attributes.push(KeyValue::new(

--- a/src/semconv.rs
+++ b/src/semconv.rs
@@ -1,8 +1,0 @@
-pub use opentelemetry_semantic_conventions::attribute::*;
-
-#[allow(deprecated)]
-pub mod legacy {
-    pub const DB_NAME: &str = super::DB_NAME;
-    pub const DB_OPERATION: &str = super::DB_OPERATION;
-    pub const MESSAGING_OPERATION: &str = super::MESSAGING_OPERATION;
-}


### PR DESCRIPTION
This is a follow-up PR for https://github.com/nentgroup/telemetry-rust/pull/54 to cleanup unused legacy tags.

We have to keep sending `db.name` since Splunk relies on it for inferring database operation spans, but other legacy spans could be safely removed.