### PR TITLE
Deprecate OtelInResponseLayer layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ instead of
 OtelAxumLayer::default()
 ```
 
+- **breaking:** Deprecate `OtelInResponseLayer` https://github.com/nentgroup/telemetry-rust/pull/124
+
+Instead use `OtelAxumLayer` with `inject_context` set to `true`
+
+```rust
+OtelAxumLayer::new(MatchedPath::as_str).inject_context(true)
+```
+
 ## v4.1.0
 
 - Add `trace_id` and `span_id` to json logs https://github.com/nentgroup/telemetry-rust/pull/126

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -1366,9 +1366,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1620,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2083,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry-instrumentation-sdk"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dda3080d8657b99ddd303a4bda25ebd3479820abbd5a67af70a9dafd06b1713"
+checksum = "a13836788f587ab71400ef44b07196430782b5e483e189933c38dddb81381574"
 dependencies = [
  "http 1.3.1",
  "opentelemetry",

--- a/src/middleware/axum.rs
+++ b/src/middleware/axum.rs
@@ -149,14 +149,15 @@ where
         let _guard = this.span.enter();
         let mut result = futures_util::ready!(this.inner.poll(cx));
         otel_http::http_server::update_span_from_response_or_error(this.span, &result);
-        if *this.inject_context {
-            if let Ok(response) = result.as_mut() {
-                otel_http::inject_context(
-                    &tracing_opentelemetry_instrumentation_sdk::find_current_context(),
-                    response.headers_mut(),
-                );
-            }
+        if *this.inject_context
+            && let Ok(response) = result.as_mut()
+        {
+            otel_http::inject_context(
+                &tracing_opentelemetry_instrumentation_sdk::find_current_context(),
+                response.headers_mut(),
+            );
         }
+
         Poll::Ready(result)
     }
 }


### PR DESCRIPTION
Here is another enchantment to remove unnecessary `OtelInResponseLayer` layer, so that instead of

```rust
        .layer(OtelInResponseLayer)
        .layer(OtelAxumLayer::new(MatchedPath::as_str))
```

we could write simply

```rust
        .layer(OtelAxumLayer::new(MatchedPath::as_str).inject_context(true))
```

I don't see any use cases for `OtelInResponseLayer` to exists as a separate layer since we are never going to use it without `OtelAxumLayer`.