### PR TITLE
Add `trace_id` and `span_id` to json logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,6 +1757,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-opentelemetry-instrumentation-sdk",
+ "tracing-serde",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,9 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
   "json",
   "ansi"
 ] }
-serde = { version = "1.0.200", features = ["derive"], optional = true }
-serde_json = { version = "1.0.116", optional = true }
+serde = { version = "1.0.200", features = ["derive"] }
+serde_json = "1.0.116"
+tracing-serde = "0.2.0"
 opentelemetry_api = { version = "0.20.0", features = ["testing"], optional = true }
 rand = { version = "0.9.0", optional = true }
 tower = { version = "0.5", optional = true }
@@ -51,7 +52,7 @@ full = ["aws-full", "test"]
 default = ["zipkin"]
 zipkin = ["dep:opentelemetry-zipkin"]
 future = ["dep:pin-project-lite"]
-test = ["axum", "dep:serde", "dep:serde_json", "dep:opentelemetry_api", "dep:rand", "dep:http-body-util", "dep:hyper"]
+test = ["axum", "dep:opentelemetry_api", "dep:rand", "dep:http-body-util", "dep:hyper"]
 axum = ["dep:axum", "dep:tower", "dep:futures-util", "dep:pin-project-lite"]
 aws-span = ["dep:aws-types", "dep:paste"]
 aws-instrumentation = ["future"]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -152,10 +152,12 @@ where
 enum Value<'a> {
     Null,
     Bool(bool),
-    PosInt(u64),
-    NegInt(i64),
-    Float(f64),
-    String(&'a str),
+    U64(u64),
+    I64(i64),
+    U128(u128),
+    I128(i128),
+    F64(f64),
+    Str(&'a str),
 }
 
 struct SerializerVisior<'a, S: SerializeMap>(&'a mut S);

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,8 +1,10 @@
 use opentelemetry::trace::TraceContextExt;
 use serde::{
-    de::{Error, MapAccess, Visitor as DeVisitor}, ser::{SerializeMap, SerializeSeq}, Deserialize, Deserializer as _, Serialize, Serializer as _
+    Deserialize, Deserializer as _, Serialize, Serializer as _,
+    de::{Error, MapAccess, Visitor as DeVisitor},
+    ser::{SerializeMap, SerializeSeq},
 };
-use serde_json::{Deserializer, Serializer, Value};
+use serde_json::{Deserializer, Serializer};
 use std::{fmt, io, marker::PhantomData, ops::Deref, str};
 use tracing::{Event, Span, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -145,6 +147,20 @@ where
         }
         serializer.end()
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum Value<'a> {
+    Null,
+    Bool(bool),
+    U64(u64),
+    I64(i64),
+    U128(u128),
+    I128(i128),
+    F64(f64),
+    Str(&'a str),
+    String(String),
 }
 
 struct SerializerVisior<'a, S: SerializeMap>(&'a mut S);

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,0 +1,157 @@
+use opentelemetry::trace::TraceContextExt;
+use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer as _};
+use serde_json::Serializer;
+use std::{collections::HashMap, fmt, io, marker::PhantomData, ops::Deref, str};
+use tracing::{Event, Span, Subscriber};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_serde::{AsSerde, SerdeMapVisitor};
+use tracing_subscriber::{
+    fmt::{
+        FmtContext, FormatEvent, FormatFields, FormattedFields,
+        format::Writer,
+        time::{FormatTime, SystemTime},
+    },
+    registry::{LookupSpan, SpanRef},
+};
+
+struct IoWriter<'a>(&'a mut dyn fmt::Write);
+
+impl io::Write for IoWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let s = str::from_utf8(buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        self.0.write_str(s).map_err(io::Error::other)?;
+
+        Ok(s.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub struct JsonFormat;
+
+impl<S, N> FormatEvent<S, N> for JsonFormat
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let mut timestamp = String::new();
+        SystemTime.format_time(&mut Writer::new(&mut timestamp))?;
+
+        let meta = event.metadata();
+
+        let mut visit = || {
+            let mut serializer = Serializer::new(IoWriter(&mut writer));
+            let mut serializer = serializer.serialize_map(None)?;
+
+            serializer.serialize_entry("timestamp", &timestamp)?;
+            serializer.serialize_entry("level", &meta.level().as_serde())?;
+
+            // add all event fields to the json object
+            let mut visitor = SerdeMapVisitor::new(serializer);
+            event.record(&mut visitor);
+            serializer = visitor.take_serializer()?;
+
+            serializer.serialize_entry("target", meta.target())?;
+
+            // extract tracing information from the current span context
+            let current_span = Span::current();
+            if let Some(id) = current_span.id() {
+                let otel_ctx = current_span.context();
+                let span_ref = otel_ctx.span();
+                let span_context = span_ref.span_context();
+
+                if let Some(leaf_span) = ctx.span(&id).or_else(|| ctx.lookup_current()) {
+                    serializer.serialize_entry(
+                        "spans",
+                        &SpanScope(leaf_span, PhantomData::<N>),
+                    )?;
+                }
+
+                let trace_id = span_context.trace_id().to_string();
+                serializer.serialize_entry("trace_id", &trace_id)?;
+
+                let span_id = span_context.span_id().to_string();
+                serializer.serialize_entry("span_id", &span_id)?;
+            }
+
+            SerializeMap::end(serializer)
+        };
+
+        visit().map_err(|_| fmt::Error)?;
+        writeln!(writer)
+    }
+}
+
+struct SpanData<'a, R, N>(SpanRef<'a, R>, PhantomData<N>)
+where
+    R: for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static;
+
+impl<R, N> Serialize for SpanData<'_, R, N>
+where
+    R: for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut serializer = serializer.serialize_map(None)?;
+
+        let extensions = self.0.extensions();
+        let mut name = self.0.name();
+
+        if let Some(fields) = extensions.get::<FormattedFields<N>>() {
+            match serde_json::from_str::<HashMap<&str, &str>>(fields) {
+                Ok(data) => {
+                    for (key, value) in data.into_iter() {
+                        if key == "name" {
+                            name = value;
+                        } else {
+                            serializer.serialize_entry(key, value)?;
+                        }
+                    }
+                }
+                Err(err) => {
+                    serializer.serialize_entry("raw_fields", fields.deref())?;
+                    serializer.serialize_entry("fields_error", &format!("{err:?}"))?;
+                }
+            }
+        }
+        serializer.serialize_entry("name", name)?;
+
+        serializer.end()
+    }
+}
+
+struct SpanScope<'a, R, N>(SpanRef<'a, R>, PhantomData<N>)
+where
+    R: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static;
+
+impl<R, N> Serialize for SpanScope<'_, R, N>
+where
+    R: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut serializer = serializer.serialize_seq(None)?;
+        for span in self.0.scope().from_root() {
+            serializer.serialize_element(&SpanData(span, self.1))?;
+        }
+        serializer.end()
+    }
+}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -16,23 +16,6 @@ use tracing_subscriber::{
     registry::{LookupSpan, SpanRef},
 };
 
-struct IoWriter<'a>(&'a mut dyn fmt::Write);
-
-impl io::Write for IoWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        let s = str::from_utf8(buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-
-        self.0.write_str(s).map_err(io::Error::other)?;
-
-        Ok(s.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
 pub struct JsonFormat;
 
 impl<S, N> FormatEvent<S, N> for JsonFormat
@@ -91,6 +74,23 @@ where
 
         visit().map_err(|_| fmt::Error)?;
         writeln!(writer)
+    }
+}
+
+struct IoWriter<'a>(&'a mut dyn fmt::Write);
+
+impl io::Write for IoWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let s = str::from_utf8(buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        self.0.write_str(s).map_err(io::Error::other)?;
+
+        Ok(s.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -2,7 +2,7 @@ use opentelemetry::trace::TraceContextExt;
 use serde::{
     de::{Error, MapAccess, Visitor as DeVisitor}, ser::{SerializeMap, SerializeSeq}, Deserialize, Deserializer as _, Serialize, Serializer as _
 };
-use serde_json::{Deserializer, Serializer};
+use serde_json::{Deserializer, Serializer, Value};
 use std::{fmt, io, marker::PhantomData, ops::Deref, str};
 use tracing::{Event, Span, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -145,19 +145,6 @@ where
         }
         serializer.end()
     }
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-enum Value<'a> {
-    Null,
-    Bool(bool),
-    U64(u64),
-    I64(i64),
-    U128(u128),
-    I128(i128),
-    F64(f64),
-    Str(&'a str),
 }
 
 struct SerializerVisior<'a, S: SerializeMap>(&'a mut S);

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -58,10 +58,8 @@ where
                 let span_context = span_ref.span_context();
 
                 if let Some(leaf_span) = ctx.span(&id).or_else(|| ctx.lookup_current()) {
-                    serializer.serialize_entry(
-                        "spans",
-                        &SpanScope(leaf_span, PhantomData::<N>),
-                    )?;
+                    let spans = SpanScope(leaf_span, PhantomData::<N>);
+                    serializer.serialize_entry("spans", &spans)?;
                 }
 
                 let trace_id = span_context.trace_id().to_string();
@@ -106,10 +104,7 @@ where
     R: for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut serializer = serializer.serialize_map(None)?;
         serializer.serialize_entry("name", self.0.name())?;
 
@@ -137,10 +132,7 @@ where
     R: Subscriber + for<'lookup> LookupSpan<'lookup>,
     N: for<'writer> FormatFields<'writer> + 'static,
 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut serializer = serializer.serialize_seq(None)?;
         for span in self.0.scope().from_root() {
             serializer.serialize_element(&SpanData(span, self.1))?;

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -191,7 +191,7 @@ mod tests {
     #[case("null")]
     #[case("42")]
     fn test_borrowed_field_value(#[case] value: &str) {
-        let json = serde_json::to_string(value).unwrap();
+        let json = format!("\"{value}\"");
         let actual = serde_json::from_str::<FieldValue>(&json)
             .map_err(|err| format!("Error parsing {json:?}: {err:?}"))
             .unwrap();

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -113,8 +113,8 @@ where
             let mut deserializer = Deserializer::from_str(fields);
             let visitor = SerializerVisior(&mut serializer);
             if let Err(error) = deserializer.deserialize_map(visitor) {
-                serializer.serialize_entry("raw_fields", fields.deref())?;
-                serializer.serialize_entry("fields_error", &format!("{error:?}"))?;
+                serializer.serialize_entry("formatted_fields", fields.deref())?;
+                serializer.serialize_entry("parsing_error", &format!("{error:?}"))?;
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub use opentelemetry_sdk::{
 pub use opentelemetry_semantic_conventions::attribute as semconv;
 pub use tracing_opentelemetry::{OpenTelemetryLayer, OpenTelemetrySpanExt};
 
+pub mod fmt;
 pub mod http;
 pub mod middleware;
 pub mod otlp;
@@ -84,11 +85,7 @@ macro_rules! fmt_layer {
         #[cfg(debug_assertions)]
         let layer = layer.compact().with_span_events(FmtSpan::CLOSE);
         #[cfg(not(debug_assertions))]
-        let layer = layer
-            .json()
-            .flatten_event(true)
-            .with_current_span(false)
-            .with_span_list(true);
+        let layer = layer.json().event_format(fmt::JsonFormat);
 
         layer.with_writer(std::io::stdout)
     }};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,18 @@ pub fn init_tracing_with_fallbacks(
         propagation::TextMapSplitPropagator::from_env().expect("TextMapPropagator setup"),
     );
 
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .event_format(fmt::JsonFormat)
+        // .flatten_event(true)
+        // .with_current_span(false)
+        // .with_span_list(true)
+        .with_writer(std::io::stdout);
     let otel_layer =
         OpenTelemetryLayer::new(tracer_provider.tracer(env!("CARGO_PKG_NAME")));
     let subscriber = tracing_subscriber::registry()
         .with(Into::<filter::TracingFilter>::into(log_level))
-        .with(fmt_layer!())
+        .with(fmt_layer)
         .with(otel_layer);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,18 +113,11 @@ pub fn init_tracing_with_fallbacks(
         propagation::TextMapSplitPropagator::from_env().expect("TextMapPropagator setup"),
     );
 
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .json()
-        .event_format(fmt::JsonFormat)
-        // .flatten_event(true)
-        // .with_current_span(false)
-        // .with_span_list(true)
-        .with_writer(std::io::stdout);
     let otel_layer =
         OpenTelemetryLayer::new(tracer_provider.tracer(env!("CARGO_PKG_NAME")));
     let subscriber = tracing_subscriber::registry()
         .with(Into::<filter::TracingFilter>::into(log_level))
-        .with(fmt_layer)
+        .with(fmt_layer!())
         .with(otel_layer);
     tracing::subscriber::set_global_default(subscriber).unwrap();
 


### PR DESCRIPTION
This pull request introduces a custom `JsonFormat` implementing `FormatEvent` to be used in place of `Format<Json>` provided by `tracing_subscriber`.

Unlike `Format<Json>`, custom `JsonFormat` is not configurable and comes with predefined set of fields, but we do not expose any way to configure those fields anyway.

The new `JsonFormat` is based on `Format<Json>`, but introduces two changes:

 * It outputs span and trace ids
 * Spans list is generated using slightly more optimal appriach due to the `SerializerVisior` I introduced to avoid parsing the entire `FormattedFields` object to `serde::Value`

New log format:

```json
{
    "timestamp": "2025-07-18T08:14:02.270575Z",
    "level": "ERROR",
    "message": "Unable to create a default profile \"test1\"",
    "target": "profiles::routes::profiles",
    "spans": [
        {
            "name": "HTTP request",
            "http.request.method": "POST",
            "http.route": "/profiles/users/{user_id}/profiles",
            "network.protocol.version": "1.1",
            "otel.kind": "Server",
            "otel.name": "POST /profiles/users/{user_id}/profiles",
            "server.address": "localhost:4000",
            "span.type": "web",
            "url.path": "/profiles/users/test1/profiles",
            "url.scheme": "",
            "user_agent.original": "HTTPie/3.2.4"
        }
    ],
    "trace_id": "d48fdaeefaa439a5dbf4ae1bb66e7c68",
    "span_id": "473ba56eb9850269"
}
```

The same log formatted using `Format<Json>` for comparison:

```json
{
    "timestamp": "2025-07-18T08:17:11.016562Z",
    "level": "ERROR",
    "message": "Unable to create a default profile \"test1\"",
    "target": "profiles::routes::profiles",
    "spans": [
        {
            "http.request.method": "POST",
            "http.route": "/profiles/users/{user_id}/profiles",
            "network.protocol.version": "1.1",
            "otel.kind": "Server",
            "otel.name": "POST /profiles/users/{user_id}/profiles",
            "server.address": "localhost:4000",
            "span.type": "web",
            "url.path": "/profiles/users/test1/profiles",
            "url.scheme": "",
            "user_agent.original": "HTTPie/3.2.4",
            "name": "HTTP request"
        }
    ]
}
```

Also, we have full control over the logs format now in case we want to change it in any way.