### PR TITLE
Update MessagingOperationKind spec and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.0
+
+- Update `MessagingOperationKind` to follow the latest Semantic conventions spec https://github.com/nentgroup/telemetry-rust/pull/129
+
 ## v5.0.0
 
 - **breaking:** New axum version agnostic way to construct `OtelAxumLayer` https://github.com/nentgroup/telemetry-rust/pull/123

--- a/src/middleware/aws/operations/firehose.rs
+++ b/src/middleware/aws/operations/firehose.rs
@@ -65,7 +65,7 @@ macro_rules! firehose_stream_operation {
 
 // publish operation
 firehose_publish_operation!(put_record, MessagingOperationKind::Create);
-firehose_publish_operation!(put_record_batch, MessagingOperationKind::Publish);
+firehose_publish_operation!(put_record_batch, MessagingOperationKind::Send);
 
 // global operations
 firehose_global_operation!(list_delivery_streams);

--- a/src/middleware/aws/operations/mod.rs
+++ b/src/middleware/aws/operations/mod.rs
@@ -10,19 +10,37 @@ pub use dynamodb::DynamodbSpanBuilder;
 pub use firehose::FirehoseSpanBuilder;
 pub use sns::SnsSpanBuilder;
 
+/// Messaging operation type
+///
+/// Represents well-known `messaging.operation.type` values from
+/// [Semantic conventions specification](https://opentelemetry.io/docs/specs/semconv/registry/attributes/messaging/).
 pub enum MessagingOperationKind {
-    Publish,
+    /// A message is created. “Create” spans always refer to a single message
+    /// and are used to provide a unique creation context for messages in batch sending scenarios.
     Create,
+    /// One or more messages are processed by a consumer.
+    Process,
+    /// One or more messages are requested by a consumer. This operation refers to pull-based scenarios,
+    /// where consumers explicitly call methods of messaging SDKs to receive messages.
     Receive,
+    /// One or more messages are provided for sending to an intermediary.
+    /// If a single message is sent, the context of the “Send” span can be used as the creation context
+    /// and no “Create” span needs to be created.
+    Send,
+    /// One or more messages are settled.
+    Settle,
+    /// Custom value representing control operations over messanging resources.
     Control,
 }
 
 impl MessagingOperationKind {
     pub fn as_str(&self) -> &'static str {
         match self {
-            MessagingOperationKind::Publish => "publish",
             MessagingOperationKind::Create => "create",
+            MessagingOperationKind::Process => "process",
             MessagingOperationKind::Receive => "receive",
+            MessagingOperationKind::Send => "send",
+            MessagingOperationKind::Settle => "settle",
             MessagingOperationKind::Control => "control",
         }
     }
@@ -38,9 +56,11 @@ impl From<MessagingOperationKind> for SpanKind {
     #[inline]
     fn from(kind: MessagingOperationKind) -> Self {
         match kind {
-            MessagingOperationKind::Publish => SpanKind::Producer,
             MessagingOperationKind::Create => SpanKind::Producer,
+            MessagingOperationKind::Process => SpanKind::Consumer,
             MessagingOperationKind::Receive => SpanKind::Consumer,
+            MessagingOperationKind::Settle => SpanKind::Producer,
+            MessagingOperationKind::Send => SpanKind::Producer,
             MessagingOperationKind::Control => SpanKind::Client,
         }
     }

--- a/src/middleware/aws/operations/mod.rs
+++ b/src/middleware/aws/operations/mod.rs
@@ -29,7 +29,7 @@ pub enum MessagingOperationKind {
     Send,
     /// One or more messages are settled.
     Settle,
-    /// Custom value representing control operations over messanging resources.
+    /// Custom value representing control operations over messaging resources.
     Control,
 }
 

--- a/src/middleware/aws/operations/sns.rs
+++ b/src/middleware/aws/operations/sns.rs
@@ -65,7 +65,7 @@ macro_rules! sns_topic_operation {
 
 // publish operation
 sns_publish_operation!(publish, MessagingOperationKind::Create);
-sns_publish_operation!(publish_batch, MessagingOperationKind::Publish);
+sns_publish_operation!(publish_batch, MessagingOperationKind::Send);
 
 // global operations
 sns_global_operation!(check_if_phone_number_is_opted_out);


### PR DESCRIPTION
Update `MessagingOperationKind` to follow the latest [Semantic conventions specification](https://opentelemetry.io/docs/specs/semconv/registry/attributes/messaging/)

Originally was a part of https://github.com/nentgroup/telemetry-rust/pull/128